### PR TITLE
[Refactor] 상품 조회 쿼리에 카테고리 id 기준 추가

### DIFF
--- a/src/main/java/com/nudgebank/paymentbackend/category/repository/CategoryRepository.java
+++ b/src/main/java/com/nudgebank/paymentbackend/category/repository/CategoryRepository.java
@@ -12,6 +12,7 @@ public interface CategoryRepository extends JpaRepository<MarketCategory, Long> 
             select distinct c
             from MarketCategory c
             left join fetch c.markets m
+            where c.categoryId <= 16
             order by c.categoryId, m.marketId
             """)
     List<MarketCategory> findAllWithMarketsAndMenus();


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #29 

---

### 📝 작업 내용
- 카테고리 id가 16 이하인 건에 대해서만 조회하도록 수정하였습니다.
- 통신비, 공과금, 대출 관련 건은 상품 구매 화면에서 제외됩니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 카테고리 목록 필터링 로직을 개선하여 더욱 정확한 카테고리 표시 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->