### PR TITLE
[Feat] 자동상환 api 호출 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,16 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2025.0.1")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -39,6 +49,9 @@ dependencies {
 
     //swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16")
+
+    //Feign Client
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/nudgebank/paymentbackend/PaymentBackendApplication.java
+++ b/src/main/java/com/nudgebank/paymentbackend/PaymentBackendApplication.java
@@ -2,7 +2,9 @@ package com.nudgebank.paymentbackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class PaymentBackendApplication {
 

--- a/src/main/java/com/nudgebank/paymentbackend/common/client/BankClient.java
+++ b/src/main/java/com/nudgebank/paymentbackend/common/client/BankClient.java
@@ -1,0 +1,14 @@
+package com.nudgebank.paymentbackend.common.client;
+
+import com.nudgebank.paymentbackend.payment.dto.AutoRepaymentRequest;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "bank-client", url = "${bank.server.url}")
+public interface BankClient {
+    @PostMapping("/api/auto-repayment/execute")
+    void notifyPayment(@RequestBody AutoRepaymentRequest signal);
+
+
+}

--- a/src/main/java/com/nudgebank/paymentbackend/payment/dto/AutoRepaymentRequest.java
+++ b/src/main/java/com/nudgebank/paymentbackend/payment/dto/AutoRepaymentRequest.java
@@ -1,0 +1,14 @@
+package com.nudgebank.paymentbackend.payment.dto;
+
+import com.nudgebank.paymentbackend.payment.domain.CardTransaction;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AutoRepaymentRequest {
+    Long memberId;
+    Long cardTransaction;
+}

--- a/src/main/java/com/nudgebank/paymentbackend/payment/service/PaymentService.java
+++ b/src/main/java/com/nudgebank/paymentbackend/payment/service/PaymentService.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Service
@@ -101,11 +102,13 @@ public class PaymentService {
                 new TransactionSynchronization() {
                     @Override
                     public void afterCommit() {
-                        try {
-                            bankClient.notifyPayment(signal);
-                        } catch (Exception e) {
-                            log.error("결제는 성공했지만 bank 서버와 통신 실패 : {}", e.getMessage());
-                        }
+                        CompletableFuture.runAsync(() -> {
+                            try {
+                                bankClient.notifyPayment(signal);
+                            } catch (Exception e) {
+                                log.error("결제는 성공했지만 bank 서버와 통신 실패 : {}", e.getMessage());
+                            }
+                        });
                     }
                 }
         );

--- a/src/main/java/com/nudgebank/paymentbackend/payment/service/PaymentService.java
+++ b/src/main/java/com/nudgebank/paymentbackend/payment/service/PaymentService.java
@@ -6,24 +6,26 @@ import com.nudgebank.paymentbackend.card.domain.CardStatus;
 import com.nudgebank.paymentbackend.card.exception.CardErrorCode;
 import com.nudgebank.paymentbackend.card.repository.CardRepository;
 import com.nudgebank.paymentbackend.category.domain.Market;
+import com.nudgebank.paymentbackend.common.client.BankClient;
 import com.nudgebank.paymentbackend.common.exception.BusinessException;
 import com.nudgebank.paymentbackend.payment.domain.CardTransaction;
 import com.nudgebank.paymentbackend.payment.domain.QrPaymentRequest;
-import com.nudgebank.paymentbackend.payment.dto.CreateQrPaymentRequest;
-import com.nudgebank.paymentbackend.payment.dto.CreateQrPaymentResponse;
-import com.nudgebank.paymentbackend.payment.dto.PaymentDetailResponse;
-import com.nudgebank.paymentbackend.payment.dto.PaymentStatusResponse;
+import com.nudgebank.paymentbackend.payment.dto.*;
 import com.nudgebank.paymentbackend.payment.exception.PaymentErrorCode;
 import com.nudgebank.paymentbackend.payment.repository.CardTransactionRepository;
 import com.nudgebank.paymentbackend.payment.repository.MarketRepository;
 import com.nudgebank.paymentbackend.payment.repository.QrPaymentRequestRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -35,6 +37,8 @@ public class PaymentService {
     private final CardTransactionRepository cardTransactionRepository;
     private final CardRepository cardRepository;
     private final MarketRepository marketRepository;
+
+    private final BankClient bankClient;
 
     @Transactional
     public CreateQrPaymentResponse createQrPayment(CreateQrPaymentRequest request) {
@@ -85,7 +89,26 @@ public class PaymentService {
 
         payment.markApproved(now);
         payment.getCard().getAccount().withdraw(payment.getPaymentAmount());
-        cardTransactionRepository.save(CardTransaction.from(payment, now));
+        CardTransaction transaction = CardTransaction.from(payment, now);
+        CardTransaction savedTransaction = cardTransactionRepository.save(transaction);
+
+        Long memberId = payment.getCard().getAccount().getMemberId();
+        AutoRepaymentRequest signal = new AutoRepaymentRequest(
+                memberId, savedTransaction.getTransactionId()
+        );
+
+        TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        try {
+                            bankClient.notifyPayment(signal);
+                        } catch (Exception e) {
+                            log.error("결제는 성공했지만 bank 서버와 통신 실패 : {}", e.getMessage());
+                        }
+                    }
+                }
+        );
 
         return new PaymentStatusResponse(payment.getQrId(), payment.getStatus(), now, "Payment approved.");
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,7 @@ app:
   cors:
     allowed-origin-patterns:
       - ${ALLOW_URL1:https://*.ngrok-free.dev}
+
+bank:
+  server:
+    url: http://localhost:9999

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
         format_sql: true
 
 server:
-  port: 9999
+  port: 9090
 
 app:
   cors:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,4 +27,4 @@ app:
 
 bank:
   server:
-    url: http://localhost:9999
+    url: ${BANK_SERVER_URL}


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #31 

---

### 📝 작업 내용
- 결제 완료 후, bank 서버의 자동상환 api를 호출하게 하였습니다.
- http 통신으로 FeignClient를 사용해보았습니다. 설정 및 사용이 매우 간단하다는 장점이 있습니다.
- 이 부분은 추후에 Kafka나 RabbitMQ를 사용하도록 변경할 수 있습니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 결제 승인 시 외부 은행에 비동기 알림을 전송하도록 통합(OpenFeign 기반)했습니다. 승인 응답은 기존과 동일하게 즉시 반환됩니다.
  * 은행 알림에 사용할 간단한 요청 페이로드 타입을 추가했습니다.

* **Chores**
  * 애플리케이션 기본 포트를 9999에서 9090으로 변경했습니다.
  * 외부 은행 서버 연결을 위한 설정 항목(bank.server.url)을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->