### PR TITLE
[Fix] 기본 스레드 점유 방지

### DIFF
--- a/src/main/java/com/nudgebank/paymentbackend/common/config/AsyncConfig.java
+++ b/src/main/java/com/nudgebank/paymentbackend/common/config/AsyncConfig.java
@@ -1,0 +1,21 @@
+package com.nudgebank.paymentbackend.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class AsyncConfig {
+    @Bean(name = "paymentNotifyExecutor")
+    public Executor paymentNotifyExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);   // 기본 유지 쓰레드
+        executor.setMaxPoolSize(10);  // 최대 확장 쓰레드
+        executor.setQueueCapacity(100); // 대기 큐
+        executor.setThreadNamePrefix("BankNotify-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/nudgebank/paymentbackend/payment/service/PaymentService.java
+++ b/src/main/java/com/nudgebank/paymentbackend/payment/service/PaymentService.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 @Slf4j
 @Service
@@ -40,6 +41,7 @@ public class PaymentService {
     private final MarketRepository marketRepository;
 
     private final BankClient bankClient;
+    private final Executor paymentNotifyExecutor;
 
     @Transactional
     public CreateQrPaymentResponse createQrPayment(CreateQrPaymentRequest request) {
@@ -108,7 +110,7 @@ public class PaymentService {
                             } catch (Exception e) {
                                 log.error("결제는 성공했지만 bank 서버와 통신 실패 : {}", e.getMessage());
                             }
-                        });
+                        }, paymentNotifyExecutor);
                     }
                 }
         );


### PR DESCRIPTION
커스텀 스레드를 제공하여 기본 스레드 점유로 인한 시스템 성능 저하를 방지하게 수정

## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #33 

---

### 📝 작업 내용
- 기존 코드는 bank에 결제 완료를 알리는 메소드가 jdk 기본 스레드를 점유하게 되어있었는데, 응답이 지연되는 경우 전체 시스템 성능 저하로 이어질 수 있기 때문에, 커스텀 스레드를 제공하도록 변경하였습니다. 

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선사항

* **성능 최적화**
  * 결제 알림 처리를 위한 비동기 실행 환경을 개선하여 시스템의 리소스 관리 효율성과 안정성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->